### PR TITLE
feat: add basic error traceability

### DIFF
--- a/packages/kit/src/createSliceMachineActions.ts
+++ b/packages/kit/src/createSliceMachineActions.ts
@@ -39,22 +39,35 @@ export const createSliceMachineActions = (
 ): SliceMachineActions => {
 	return {
 		readLibrary: async (args) => {
-			const [library] = await hookSystem.callHook("library:read", {
+			const {
+				data: [library],
+				errors: [cause],
+			} = await hookSystem.callHook("library:read", {
 				libraryID: args.libraryID,
 			});
+
+			if (!library) {
+				throw new Error(`Library \`${args.libraryID}\` not found.`, {
+					cause,
+				});
+			}
 
 			return library;
 		},
 
 		getSliceModel: async (args) => {
-			const [model] = await hookSystem.callHook("slice:read", {
+			const {
+				data: [model],
+				errors: [cause],
+			} = await hookSystem.callHook("slice:read", {
 				libraryID: args.libraryID,
 				sliceID: args.sliceID,
 			});
 
 			if (!model) {
 				throw new Error(
-					`A "${args.sliceID}" Slice does not exist in the "${args.libraryID}" library.`,
+					`Slice \`${args.sliceID}\` not found in the \`${args.libraryID}\` library.`,
+					{ cause },
 				);
 			}
 

--- a/packages/kit/src/createSliceMachinePluginRunner.ts
+++ b/packages/kit/src/createSliceMachinePluginRunner.ts
@@ -95,11 +95,24 @@ export class SliceMachinePluginRunner {
 				  };
 
 		// Run plugin setup with actions and context
-		await plugin.setup({
-			...context,
-			hook,
-			unhook: hookSystemScope.unhook,
-		});
+		try {
+			await plugin.setup({
+				...context,
+				hook,
+				unhook: hookSystemScope.unhook,
+			});
+		} catch (error) {
+			if (error instanceof Error) {
+				throw new Error(
+					`Plugin \`${plugin.resolve}\` errored during setup: ${error.message}`,
+					{ cause: error },
+				);
+			} else {
+				throw new Error(
+					`Plugin \`${plugin.resolve}\` errored during setup: ${error}`,
+				);
+			}
+		}
 	}
 
 	private _validateAdapter(adapter: LoadedSliceMachinePlugin): void {

--- a/packages/kit/src/index.ts
+++ b/packages/kit/src/index.ts
@@ -69,7 +69,7 @@ export type {
 	SliceSimulatorSetupStepValidationMessage,
 } from "./types";
 
-export { HookSystemError } from "./lib";
+export { HookError } from "./lib";
 
 // Internal (for Slice Machine)
 

--- a/packages/kit/src/index.ts
+++ b/packages/kit/src/index.ts
@@ -69,6 +69,8 @@ export type {
 	SliceSimulatorSetupStepValidationMessage,
 } from "./types";
 
+export { HookSystemError } from "./lib";
+
 // Internal (for Slice Machine)
 
 export { createSliceMachineHookSystem } from "./createSliceMachineHookSystem";

--- a/packages/kit/src/lib/HookSystem.ts
+++ b/packages/kit/src/lib/HookSystem.ts
@@ -122,7 +122,7 @@ export class HookSystem<
 	async callHook<TName extends Extract<keyof THookFns, string>>(
 		name: TName,
 		...args: Parameters<THookFns[TName]>
-	): Promise<(Awaited<ReturnType<THookFns[TName]>> | HookSystemError)[]> {
+	): Promise<Awaited<ReturnType<THookFns[TName]>>[]> {
 		const hooks = this._registeredHooks[name] ?? [];
 
 		const promises = hooks.map(async (hook) => {

--- a/packages/kit/src/lib/index.ts
+++ b/packages/kit/src/lib/index.ts
@@ -1,2 +1,2 @@
-export { HookSystem } from "./HookSystem";
+export { HookSystem, HookSystemError } from "./HookSystem";
 export type { HookFn, CreateScopeReturnType } from "./HookSystem";

--- a/packages/kit/src/lib/index.ts
+++ b/packages/kit/src/lib/index.ts
@@ -1,2 +1,2 @@
-export { HookSystem, HookSystemError } from "./HookSystem";
+export { HookSystem, HookError } from "./HookSystem";
 export type { HookFn, CreateScopeReturnType } from "./HookSystem";

--- a/packages/kit/test/lib-HookSystem.test.ts
+++ b/packages/kit/test/lib-HookSystem.test.ts
@@ -84,7 +84,7 @@ it("returns an empty array when no hook registered", async () => {
 
 	const result = await system.callHook("hook1");
 
-	expect(result).toStrictEqual([]);
+	expect(result).toStrictEqual({ data: [], errors: [] });
 });
 
 it("returns hook returned values in order", async () => {
@@ -100,7 +100,7 @@ it("returns hook returned values in order", async () => {
 
 	const result = await system.callHook("hook1");
 
-	expect(result).toStrictEqual(["foo", "bar"]);
+	expect(result).toStrictEqual({ data: ["foo", "bar"], errors: [] });
 });
 
 it("allows inspection of owner registered hooks", () => {


### PR DESCRIPTION
This PR adds basic error traceability to the plugin kit.

I identified 4 points of failure:
1. When the plugin runner fails to load a plugin
2. When the plugin runner fails to setup a plugin
3. When the plugin runner fails to validate the adapter
4. When a hook throws.

For 1, 2, and 3 since those will happen pretty much instantly I think just throwing clear error messages from the plugin runner is enough (see implementation for details).

Regarding 4:
- I implemented a basic `HookSystemError` class that provides information about what happened and who was responsible (see implementation for details again).
- For now, as soon as one plugin throws, the whole hook throws independently of what was able to complete or not during that time period (`Promise.all()`).
- I thought about switching to `Promise.allSettled()`, but I'm unsure of the desired behavior then: Should it throw when one or more plugins throw? When all plugins throw? How would Slice Machine take an informed decision based on that?