### PR TITLE
feat: integrate with `@prismicio/types-internal`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -274,12 +274,35 @@
 			}
 		},
 		"node_modules/@prismicio/types": {
-			"version": "0.1.27",
-			"resolved": "https://registry.npmjs.org/@prismicio/types/-/types-0.1.27.tgz",
-			"integrity": "sha512-+Oc7EFcp6RGVMvFKQl9y9D4HtBhHeOtE0asfYhedCflQDf3OOzjE8POIu1bXTkk8i1kEWM3oYvz6yLN4yAyGWQ==",
+			"version": "0.1.29",
+			"resolved": "https://registry.npmjs.org/@prismicio/types/-/types-0.1.29.tgz",
+			"integrity": "sha512-wp7DHqMK0FDMcFQfJbqTAzWNBkM6/rRq71jMw6x9m07nWCUqytJQQKg6/15uduIeSqPXmyfJW21drsmChGaxsQ==",
 			"engines": {
 				"node": ">=12.7.0"
 			}
+		},
+		"node_modules/@prismicio/types-internal": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/@prismicio/types-internal/-/types-internal-0.3.0.tgz",
+			"integrity": "sha512-7/VHdr9jBE42Lhq3iqQvc91TxIx7alOSv792OZBmGBWQN1wOyEGyxwAIs4ctChHUXvt/q2RCsdp2FKpLVEq1QQ==",
+			"dependencies": {
+				"monocle-ts": "^2.3.11",
+				"newtype-ts": "^0.3.5",
+				"tslib": "^2.3.1"
+			},
+			"engines": {
+				"node": ">=12.7.0"
+			},
+			"peerDependencies": {
+				"fp-ts": "^2.11.8",
+				"io-ts": "^2.2.16",
+				"io-ts-types": "^0.5.16"
+			}
+		},
+		"node_modules/@prismicio/types-internal/node_modules/tslib": {
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+			"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
 		},
 		"node_modules/@rollup/plugin-alias": {
 			"version": "3.1.9",
@@ -575,9 +598,9 @@
 			"integrity": "sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw=="
 		},
 		"node_modules/@types/prettier": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.6.0.tgz",
-			"integrity": "sha512-G/AdOadiZhnJp0jXCaBQU449W2h716OW/EoXeYkCytxKL06X1WCXB4DZpp8TpZ8eyIJVS1cw4lrlkkSYU21cDw==",
+			"version": "2.6.3",
+			"resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.6.3.tgz",
+			"integrity": "sha512-ymZk3LEC/fsut+/Q5qejp6R9O1rMxz3XaRHDV6kX8MrGAhOSPqVARbDi+EZvInBpw+BnCX3TD240byVkOfQsHg==",
 			"dev": true
 		},
 		"node_modules/@types/resolve": {
@@ -809,7 +832,7 @@
 		"node_modules/add-stream": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/add-stream/-/add-stream-1.0.0.tgz",
-			"integrity": "sha1-anmQQ3ynNtXhKI25K9MmbV9csqo=",
+			"integrity": "sha512-qQLMr+8o0WC4FZGQTcJiKBVC59JylcPSrTtk6usvmIDFUOCKegapy1VHQwRbFMOFyb/inzUVqHs+eMYKDM1YeQ==",
 			"dev": true
 		},
 		"node_modules/ajv": {
@@ -870,7 +893,7 @@
 		"node_modules/array-ify": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/array-ify/-/array-ify-1.0.0.tgz",
-			"integrity": "sha1-nlKHYrSpBmrRY6aWKjZEGOlibs4=",
+			"integrity": "sha512-c5AMf34bKdvPhQ7tBGhqkgKNUzMr4WUs+WDtC2ZUGOUncbxKMTvqxYctiseW3+L4bA8ec+GcZ6/A/FW4m8ukng==",
 			"dev": true
 		},
 		"node_modules/array-union": {
@@ -959,9 +982,9 @@
 			}
 		},
 		"node_modules/c8": {
-			"version": "7.11.2",
-			"resolved": "https://registry.npmjs.org/c8/-/c8-7.11.2.tgz",
-			"integrity": "sha512-6ahJSrhS6TqSghHm+HnWt/8Y2+z0hM/FQyB1ybKhAR30+NYL9CTQ1uwHxuWw6U7BHlHv6wvhgOrH81I+lfCkxg==",
+			"version": "7.11.3",
+			"resolved": "https://registry.npmjs.org/c8/-/c8-7.11.3.tgz",
+			"integrity": "sha512-6YBmsaNmqRm9OS3ZbIiL2EZgi1+Xc4O24jL3vMYGE6idixYuGdy76rIfIdltSKDj9DpLNrcXSonUTR1miBD0wA==",
 			"dev": true,
 			"dependencies": {
 				"@bcoe/v8-coverage": "^0.2.3",
@@ -1385,9 +1408,9 @@
 			"dev": true
 		},
 		"node_modules/conventional-changelog": {
-			"version": "3.1.24",
-			"resolved": "https://registry.npmjs.org/conventional-changelog/-/conventional-changelog-3.1.24.tgz",
-			"integrity": "sha512-ed6k8PO00UVvhExYohroVPXcOJ/K1N0/drJHx/faTH37OIZthlecuLIRX/T6uOp682CAoVoFpu+sSEaeuH6Asg==",
+			"version": "3.1.25",
+			"resolved": "https://registry.npmjs.org/conventional-changelog/-/conventional-changelog-3.1.25.tgz",
+			"integrity": "sha512-ryhi3fd1mKf3fSjbLXOfK2D06YwKNic1nC9mWqybBHdObPd8KJ2vjaXZfYj1U23t+V8T8n0d7gwnc9XbIdFbyQ==",
 			"dev": true,
 			"dependencies": {
 				"conventional-changelog-angular": "^5.0.12",
@@ -1450,9 +1473,9 @@
 			"dev": true
 		},
 		"node_modules/conventional-changelog-conventionalcommits": {
-			"version": "4.6.1",
-			"resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-4.6.1.tgz",
-			"integrity": "sha512-lzWJpPZhbM1R0PIzkwzGBCnAkH5RKJzJfFQZcl/D+2lsJxAwGnDKBqn/F4C1RD31GJNn8NuKWQzAZDAVXPp2Mw==",
+			"version": "4.6.3",
+			"resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-4.6.3.tgz",
+			"integrity": "sha512-LTTQV4fwOM4oLPad317V/QNQ1FY4Hju5qeBIM1uTHbrnCE+Eg4CdRZ3gO2pUeR+tzWdp80M2j3qFFEDWVqOV4g==",
 			"dev": true,
 			"dependencies": {
 				"compare-func": "^2.0.0",
@@ -1701,9 +1724,9 @@
 			}
 		},
 		"node_modules/debug": {
-			"version": "4.3.3",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
-			"integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+			"version": "4.3.4",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+			"integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
 			"dev": true,
 			"dependencies": {
 				"ms": "2.1.2"
@@ -2884,17 +2907,11 @@
 				"node": ">=12.20.0"
 			}
 		},
-		"node_modules/fs-access": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/fs-access/-/fs-access-1.0.1.tgz",
-			"integrity": "sha1-1qh/JiJxzv6+wwxVNAf7mV2od3o=",
-			"dev": true,
-			"dependencies": {
-				"null-check": "^1.0.0"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
+		"node_modules/fp-ts": {
+			"version": "2.12.1",
+			"resolved": "https://registry.npmjs.org/fp-ts/-/fp-ts-2.12.1.tgz",
+			"integrity": "sha512-oxvgqUYR6O9VkKXrxkJ0NOyU0FrE705MeqgBUMEPWyTu6Pwn768cJbHChw2XOBlgFLKfIHxjr2OOBFpv2mUGZw==",
+			"peer": true
 		},
 		"node_modules/fs-extra": {
 			"version": "10.0.0",
@@ -3084,7 +3101,7 @@
 		"node_modules/git-remote-origin-url": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/git-remote-origin-url/-/git-remote-origin-url-2.0.0.tgz",
-			"integrity": "sha1-UoJlna4hBxRaERJhEq0yFuxfpl8=",
+			"integrity": "sha512-eU+GGrZgccNJcsDH5LkXR3PB9M958hxc7sbA8DFJjrv9j4L2P/eZfKhM+QD6wyzpiv+b1BpK0XrYCxkovtjSLw==",
 			"dev": true,
 			"dependencies": {
 				"gitconfiglocal": "^1.0.0",
@@ -3122,7 +3139,7 @@
 		"node_modules/gitconfiglocal": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/gitconfiglocal/-/gitconfiglocal-1.0.0.tgz",
-			"integrity": "sha1-QdBF84UaXqiPA/JMocYXgRRGS5s=",
+			"integrity": "sha512-spLUXeTAVHxDtKsJc8FkFVgFtMdEN9qPGpL23VfSHx4fP4+Ds097IXLvymbnDH8FnmxX5Nr9bPw3A+AQ6mWEaQ==",
 			"dev": true,
 			"dependencies": {
 				"ini": "^1.3.2"
@@ -3219,15 +3236,6 @@
 			},
 			"optionalDependencies": {
 				"uglify-js": "^3.1.4"
-			}
-		},
-		"node_modules/handlebars/node_modules/source-map": {
-			"version": "0.6.1",
-			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-			"dev": true,
-			"engines": {
-				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/hard-rejection": {
@@ -3435,6 +3443,27 @@
 			},
 			"engines": {
 				"node": ">= 0.4"
+			}
+		},
+		"node_modules/io-ts": {
+			"version": "2.2.16",
+			"resolved": "https://registry.npmjs.org/io-ts/-/io-ts-2.2.16.tgz",
+			"integrity": "sha512-y5TTSa6VP6le0hhmIyN0dqEXkrZeJLeC5KApJq6VLci3UEKF80lZ+KuoUs02RhBxNWlrqSNxzfI7otLX1Euv8Q==",
+			"peer": true,
+			"peerDependencies": {
+				"fp-ts": "^2.5.0"
+			}
+		},
+		"node_modules/io-ts-types": {
+			"version": "0.5.16",
+			"resolved": "https://registry.npmjs.org/io-ts-types/-/io-ts-types-0.5.16.tgz",
+			"integrity": "sha512-h9noYVfY9rlbmKI902SJdnV/06jgiT2chxG6lYDxaYNp88HscPi+SBCtmcU+m0E7WT5QSwt7sIMj93+qu0FEwQ==",
+			"peer": true,
+			"peerDependencies": {
+				"fp-ts": "^2.0.0",
+				"io-ts": "^2.0.0",
+				"monocle-ts": "^2.0.0",
+				"newtype-ts": "^0.3.2"
 			}
 		},
 		"node_modules/is-arrayish": {
@@ -3713,7 +3742,7 @@
 		"node_modules/isarray": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+			"integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
 			"dev": true
 		},
 		"node_modules/isexe": {
@@ -3836,7 +3865,7 @@
 		"node_modules/json-stringify-safe": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-			"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+			"integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
 			"dev": true
 		},
 		"node_modules/jsonc-parser": {
@@ -4691,9 +4720,9 @@
 			}
 		},
 		"node_modules/minimist": {
-			"version": "1.2.5",
-			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-			"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+			"version": "1.2.6",
+			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+			"integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
 			"dev": true
 		},
 		"node_modules/minimist-options": {
@@ -5030,6 +5059,14 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/monocle-ts": {
+			"version": "2.3.13",
+			"resolved": "https://registry.npmjs.org/monocle-ts/-/monocle-ts-2.3.13.tgz",
+			"integrity": "sha512-D5Ygd3oulEoAm3KuGO0eeJIrhFf1jlQIoEVV2DYsZUMz42j4tGxgct97Aq68+F8w4w4geEnwFa8HayTS/7lpKQ==",
+			"peerDependencies": {
+				"fp-ts": "^2.5.0"
+			}
+		},
 		"node_modules/mri": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
@@ -5040,9 +5077,9 @@
 			}
 		},
 		"node_modules/nanoid": {
-			"version": "3.3.2",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.2.tgz",
-			"integrity": "sha512-CuHBogktKwpm5g2sRgv83jEy2ijFzBwMoYA60orPDR7ynsLijJDqgsi4RDGj3OJpy3Ieb+LYwiRmIOGyytgITA==",
+			"version": "3.3.4",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
+			"integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==",
 			"dev": true,
 			"bin": {
 				"nanoid": "bin/nanoid.cjs"
@@ -5071,6 +5108,15 @@
 			"resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
 			"integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
 			"dev": true
+		},
+		"node_modules/newtype-ts": {
+			"version": "0.3.5",
+			"resolved": "https://registry.npmjs.org/newtype-ts/-/newtype-ts-0.3.5.tgz",
+			"integrity": "sha512-v83UEQMlVR75yf1OUdoSFssjitxzjZlqBAjiGQ4WJaML8Jdc68LJ+BaSAXUmKY4bNzp7hygkKLYTsDi14PxI2g==",
+			"peerDependencies": {
+				"fp-ts": "^2.0.0",
+				"monocle-ts": "^2.0.0"
+			}
 		},
 		"node_modules/nice-try": {
 			"version": "1.0.5",
@@ -5252,15 +5298,6 @@
 			},
 			"engines": {
 				"node": ">=8"
-			}
-		},
-		"node_modules/null-check": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/null-check/-/null-check-1.0.0.tgz",
-			"integrity": "sha1-l33/1xdgErnsMNKjnbXPcqBDnt0=",
-			"dev": true,
-			"engines": {
-				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/object-inspect": {
@@ -5553,16 +5590,16 @@
 		"node_modules/pify": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-			"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+			"integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
 			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/postcss": {
-			"version": "8.4.12",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.12.tgz",
-			"integrity": "sha512-lg6eITwYe9v6Hr5CncVbK70SoioNQIq81nsaG86ev5hAidQvmOeETBqs7jm43K2F5/Ley3ytDtriImV6TpNiSg==",
+			"version": "8.4.14",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.14.tgz",
+			"integrity": "sha512-E398TUmfAYFPBSdzgeieK2Y1+1cpdxJx8yXbK/m57nRhKSmk1GB2tO4lbLBtlkfPQTDKfe4Xqv1ASWPpayPEig==",
 			"dev": true,
 			"funding": [
 				{
@@ -5575,7 +5612,7 @@
 				}
 			],
 			"dependencies": {
-				"nanoid": "^3.3.1",
+				"nanoid": "^3.3.4",
 				"picocolors": "^1.0.0",
 				"source-map-js": "^1.0.2"
 			},
@@ -5593,9 +5630,9 @@
 			}
 		},
 		"node_modules/prettier": {
-			"version": "2.6.2",
-			"resolved": "https://registry.npmjs.org/prettier/-/prettier-2.6.2.tgz",
-			"integrity": "sha512-PkUpF+qoXTqhOeWL9fu7As8LXsIUZ1WYaJiY/a7McAQzxjk82OF0tibkFXVCDImZtWxbvojFjerkiLb0/q8mew==",
+			"version": "2.7.1",
+			"resolved": "https://registry.npmjs.org/prettier/-/prettier-2.7.1.tgz",
+			"integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==",
 			"bin": {
 				"prettier": "bin-prettier.js"
 			},
@@ -5951,7 +5988,7 @@
 		"node_modules/read-pkg-up": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
-			"integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
+			"integrity": "sha512-YFzFrVvpC6frF1sz8psoHDBGF7fLPc+llq/8NB43oagqWkx8ar5zYtsTORtOjw9W2RHLpWP+zTWwBvf1bCmcSw==",
 			"dev": true,
 			"dependencies": {
 				"find-up": "^2.0.0",
@@ -5964,7 +6001,7 @@
 		"node_modules/read-pkg-up/node_modules/find-up": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-			"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+			"integrity": "sha512-NWzkk0jSJtTt08+FBFMvXoeZnOJD+jTtsRmBYbAIzJdX6l7dLgR7CTubCM5/eDdPUBvLCeVasP1brfVR/9/EZQ==",
 			"dev": true,
 			"dependencies": {
 				"locate-path": "^2.0.0"
@@ -5976,7 +6013,7 @@
 		"node_modules/read-pkg-up/node_modules/locate-path": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
-			"integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+			"integrity": "sha512-NCI2kiDkyR7VeEKm27Kda/iQHyKJe1Bu0FlTbYp3CqJu+9IFe9bLyAjMxf5ZDDbEg+iMPzB5zYyUTSm8wVTKmA==",
 			"dev": true,
 			"dependencies": {
 				"p-locate": "^2.0.0",
@@ -6001,7 +6038,7 @@
 		"node_modules/read-pkg-up/node_modules/p-locate": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
-			"integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+			"integrity": "sha512-nQja7m7gSKuewoVRen45CtVfODR3crN3goVQ0DDZ9N3yHxgpkuBhZqsaiotSQRrADUrne346peY7kT3TSACykg==",
 			"dev": true,
 			"dependencies": {
 				"p-limit": "^1.1.0"
@@ -6013,7 +6050,7 @@
 		"node_modules/read-pkg-up/node_modules/p-try": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
-			"integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+			"integrity": "sha512-U1etNYuMJoIz3ZXSrrySFjsXQTWOx2/jdi86L+2pRvph/qMKL6sbcCYdH23fqsbm8TH2Gn0OybpT4eSFlCVHww==",
 			"dev": true,
 			"engines": {
 				"node": ">=4"
@@ -6022,7 +6059,7 @@
 		"node_modules/read-pkg-up/node_modules/path-exists": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-			"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+			"integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
 			"dev": true,
 			"engines": {
 				"node": ">=4"
@@ -6597,6 +6634,15 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/source-map": {
+			"version": "0.6.1",
+			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
 		"node_modules/source-map-js": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
@@ -6662,22 +6708,21 @@
 			}
 		},
 		"node_modules/standard-version": {
-			"version": "9.3.2",
-			"resolved": "https://registry.npmjs.org/standard-version/-/standard-version-9.3.2.tgz",
-			"integrity": "sha512-u1rfKP4o4ew7Yjbfycv80aNMN2feTiqseAhUhrrx2XtdQGmu7gucpziXe68Z4YfHVqlxVEzo4aUA0Iu3VQOTgQ==",
+			"version": "9.5.0",
+			"resolved": "https://registry.npmjs.org/standard-version/-/standard-version-9.5.0.tgz",
+			"integrity": "sha512-3zWJ/mmZQsOaO+fOlsa0+QK90pwhNd042qEcw6hKFNoLFs7peGyvPffpEBbK/DSGPbyOvli0mUIFv5A4qTjh2Q==",
 			"dev": true,
 			"dependencies": {
 				"chalk": "^2.4.2",
-				"conventional-changelog": "3.1.24",
+				"conventional-changelog": "3.1.25",
 				"conventional-changelog-config-spec": "2.1.0",
-				"conventional-changelog-conventionalcommits": "4.6.1",
+				"conventional-changelog-conventionalcommits": "4.6.3",
 				"conventional-recommended-bump": "6.1.0",
 				"detect-indent": "^6.0.0",
 				"detect-newline": "^3.1.0",
 				"dotgitignore": "^2.1.0",
 				"figures": "^3.1.0",
 				"find-up": "^5.0.0",
-				"fs-access": "^1.0.1",
 				"git-semver-tags": "^4.0.0",
 				"semver": "^7.1.1",
 				"stringify-package": "^1.0.1",
@@ -6981,18 +7026,18 @@
 			}
 		},
 		"node_modules/tinypool": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/tinypool/-/tinypool-0.1.2.tgz",
-			"integrity": "sha512-fvtYGXoui2RpeMILfkvGIgOVkzJEGediv8UJt7TxdAOY8pnvUkFg/fkvqTfXG9Acc9S17Cnn1S4osDc2164guA==",
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/tinypool/-/tinypool-0.1.3.tgz",
+			"integrity": "sha512-2IfcQh7CP46XGWGGbdyO4pjcKqsmVqFAPcXfPxcPXmOWt9cYkTP9HcDmGgsfijYoAEc4z9qcpM/BaBz46Y9/CQ==",
 			"dev": true,
 			"engines": {
 				"node": ">=14.0.0"
 			}
 		},
 		"node_modules/tinyspy": {
-			"version": "0.3.2",
-			"resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-0.3.2.tgz",
-			"integrity": "sha512-2+40EP4D3sFYy42UkgkFFB+kiX2Tg3URG/lVvAZFfLxgGpnWl5qQJuBw1gaLttq8UOS+2p3C0WrhJnQigLTT2Q==",
+			"version": "0.3.3",
+			"resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-0.3.3.tgz",
+			"integrity": "sha512-gRiUR8fuhUf0W9lzojPf1N1euJYA30ISebSfgca8z76FOvXtVXqd5ojEIaKLWbDQhAaC3ibxZIjqbyi4ybjcTw==",
 			"dev": true,
 			"engines": {
 				"node": ">=14.0.0"
@@ -7088,9 +7133,9 @@
 			"dev": true
 		},
 		"node_modules/typescript": {
-			"version": "4.6.4",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.4.tgz",
-			"integrity": "sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==",
+			"version": "4.7.4",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
+			"integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
 			"dev": true,
 			"bin": {
 				"tsc": "bin/tsc",
@@ -7101,9 +7146,9 @@
 			}
 		},
 		"node_modules/uglify-js": {
-			"version": "3.15.1",
-			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.15.1.tgz",
-			"integrity": "sha512-FAGKF12fWdkpvNJZENacOH0e/83eG6JyVQyanIJaBXCN1J11TUQv1T1/z8S+Z0CG0ZPk1nPcreF/c7lrTd0TEQ==",
+			"version": "3.16.1",
+			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.16.1.tgz",
+			"integrity": "sha512-X5BGTIDH8U6IQ1TIRP62YC36k+ULAa1d59BxlWvPUJ1NkW5L3FwcGfEzuVvGmhJFBu0YJ5Ge25tmRISqCmLiRQ==",
 			"dev": true,
 			"optional": true,
 			"bin": {
@@ -7253,13 +7298,13 @@
 			}
 		},
 		"node_modules/vite": {
-			"version": "2.9.6",
-			"resolved": "https://registry.npmjs.org/vite/-/vite-2.9.6.tgz",
-			"integrity": "sha512-3IffdrByHW95Yjv0a13TQOQfJs7L5dVlSPuTt432XLbRMriWbThqJN2k/IS6kXn5WY4xBLhK9XoaWay1B8VzUw==",
+			"version": "2.9.12",
+			"resolved": "https://registry.npmjs.org/vite/-/vite-2.9.12.tgz",
+			"integrity": "sha512-suxC36dQo9Rq1qMB2qiRorNJtJAdxguu5TMvBHOc/F370KvqAe9t48vYp+/TbPKRNrMh/J55tOUmkuIqstZaew==",
 			"dev": true,
 			"dependencies": {
 				"esbuild": "^0.14.27",
-				"postcss": "^8.4.12",
+				"postcss": "^8.4.13",
 				"resolve": "^1.22.0",
 				"rollup": "^2.59.0"
 			},
@@ -7401,7 +7446,7 @@
 		"node_modules/wordwrap": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-			"integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+			"integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
 			"dev": true
 		},
 		"node_modules/wrap-ansi": {
@@ -7585,19 +7630,20 @@
 			"version": "0.0.0",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@prismicio/types": "^0.1.27",
+				"@prismicio/types": "^0.1.29",
+				"@prismicio/types-internal": "^0.3.0",
 				"defu": "^6.0.0",
-				"prettier": "^2.6.2",
+				"prettier": "^2.7.1",
 				"strip-indent": "^4.0.0"
 			},
 			"devDependencies": {
 				"@prismicio/mock": "^0.0.10",
-				"@types/prettier": "^2.6.0",
-				"c8": "^7.11.2",
+				"@types/prettier": "^2.6.3",
+				"c8": "^7.11.3",
 				"siroc": "^0.16.0",
-				"standard-version": "^9.3.2",
-				"typescript": "^4.6.4",
-				"vitest": "^0.10.0"
+				"standard-version": "^9.5.0",
+				"typescript": "^4.7.4",
+				"vitest": "^0.15.2"
 			},
 			"engines": {
 				"node": ">=12.7.0"
@@ -7620,6 +7666,52 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"packages/kit/node_modules/vitest": {
+			"version": "0.15.2",
+			"resolved": "https://registry.npmjs.org/vitest/-/vitest-0.15.2.tgz",
+			"integrity": "sha512-cMabuUqu+nNHafkdN7H8Z20+UZTrrUfqjGwAoLwUwrqFGWBz3gXwxndjbLf6mgSFs9lF/JWjKeNM1CXKwtk26w==",
+			"dev": true,
+			"dependencies": {
+				"@types/chai": "^4.3.1",
+				"@types/chai-subset": "^1.3.3",
+				"@types/node": "*",
+				"chai": "^4.3.6",
+				"debug": "^4.3.4",
+				"local-pkg": "^0.4.1",
+				"tinypool": "^0.1.3",
+				"tinyspy": "^0.3.3",
+				"vite": "^2.9.12"
+			},
+			"bin": {
+				"vitest": "vitest.mjs"
+			},
+			"engines": {
+				"node": ">=v14.16.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/antfu"
+			},
+			"peerDependencies": {
+				"@vitest/ui": "*",
+				"c8": "*",
+				"happy-dom": "*",
+				"jsdom": "*"
+			},
+			"peerDependenciesMeta": {
+				"@vitest/ui": {
+					"optional": true
+				},
+				"c8": {
+					"optional": true
+				},
+				"happy-dom": {
+					"optional": true
+				},
+				"jsdom": {
+					"optional": true
+				}
 			}
 		},
 		"packages/test-utils": {
@@ -7842,9 +7934,26 @@
 			}
 		},
 		"@prismicio/types": {
-			"version": "0.1.27",
-			"resolved": "https://registry.npmjs.org/@prismicio/types/-/types-0.1.27.tgz",
-			"integrity": "sha512-+Oc7EFcp6RGVMvFKQl9y9D4HtBhHeOtE0asfYhedCflQDf3OOzjE8POIu1bXTkk8i1kEWM3oYvz6yLN4yAyGWQ=="
+			"version": "0.1.29",
+			"resolved": "https://registry.npmjs.org/@prismicio/types/-/types-0.1.29.tgz",
+			"integrity": "sha512-wp7DHqMK0FDMcFQfJbqTAzWNBkM6/rRq71jMw6x9m07nWCUqytJQQKg6/15uduIeSqPXmyfJW21drsmChGaxsQ=="
+		},
+		"@prismicio/types-internal": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/@prismicio/types-internal/-/types-internal-0.3.0.tgz",
+			"integrity": "sha512-7/VHdr9jBE42Lhq3iqQvc91TxIx7alOSv792OZBmGBWQN1wOyEGyxwAIs4ctChHUXvt/q2RCsdp2FKpLVEq1QQ==",
+			"requires": {
+				"monocle-ts": "^2.3.11",
+				"newtype-ts": "^0.3.5",
+				"tslib": "^2.3.1"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.4.0",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+					"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+				}
+			}
 		},
 		"@rollup/plugin-alias": {
 			"version": "3.1.9",
@@ -8015,16 +8124,17 @@
 			"version": "file:packages/kit",
 			"requires": {
 				"@prismicio/mock": "^0.0.10",
-				"@prismicio/types": "^0.1.27",
-				"@types/prettier": "^2.6.0",
-				"c8": "^7.11.2",
+				"@prismicio/types": "^0.1.29",
+				"@prismicio/types-internal": "^0.3.0",
+				"@types/prettier": "^2.6.3",
+				"c8": "^7.11.3",
 				"defu": "^6.0.0",
-				"prettier": "^2.6.2",
+				"prettier": "^2.7.1",
 				"siroc": "^0.16.0",
-				"standard-version": "^9.3.2",
+				"standard-version": "^9.5.0",
 				"strip-indent": "^4.0.0",
-				"typescript": "^4.6.4",
-				"vitest": "^0.10.0"
+				"typescript": "^4.7.4",
+				"vitest": "^0.15.2"
 			},
 			"dependencies": {
 				"defu": {
@@ -8038,6 +8148,23 @@
 					"integrity": "sha512-mnVSV2l+Zv6BLpSD/8V87CW/y9EmmbYzGCIavsnsI6/nwn26DwffM/yztm30Z/I2DY9wdS3vXVCMnHDgZaVNoA==",
 					"requires": {
 						"min-indent": "^1.0.1"
+					}
+				},
+				"vitest": {
+					"version": "0.15.2",
+					"resolved": "https://registry.npmjs.org/vitest/-/vitest-0.15.2.tgz",
+					"integrity": "sha512-cMabuUqu+nNHafkdN7H8Z20+UZTrrUfqjGwAoLwUwrqFGWBz3gXwxndjbLf6mgSFs9lF/JWjKeNM1CXKwtk26w==",
+					"dev": true,
+					"requires": {
+						"@types/chai": "^4.3.1",
+						"@types/chai-subset": "^1.3.3",
+						"@types/node": "*",
+						"chai": "^4.3.6",
+						"debug": "^4.3.4",
+						"local-pkg": "^0.4.1",
+						"tinypool": "^0.1.3",
+						"tinyspy": "^0.3.3",
+						"vite": "^2.9.12"
 					}
 				}
 			}
@@ -8158,9 +8285,9 @@
 			"integrity": "sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw=="
 		},
 		"@types/prettier": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.6.0.tgz",
-			"integrity": "sha512-G/AdOadiZhnJp0jXCaBQU449W2h716OW/EoXeYkCytxKL06X1WCXB4DZpp8TpZ8eyIJVS1cw4lrlkkSYU21cDw==",
+			"version": "2.6.3",
+			"resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.6.3.tgz",
+			"integrity": "sha512-ymZk3LEC/fsut+/Q5qejp6R9O1rMxz3XaRHDV6kX8MrGAhOSPqVARbDi+EZvInBpw+BnCX3TD240byVkOfQsHg==",
 			"dev": true
 		},
 		"@types/resolve": {
@@ -8295,7 +8422,7 @@
 		"add-stream": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/add-stream/-/add-stream-1.0.0.tgz",
-			"integrity": "sha1-anmQQ3ynNtXhKI25K9MmbV9csqo=",
+			"integrity": "sha512-qQLMr+8o0WC4FZGQTcJiKBVC59JylcPSrTtk6usvmIDFUOCKegapy1VHQwRbFMOFyb/inzUVqHs+eMYKDM1YeQ==",
 			"dev": true
 		},
 		"ajv": {
@@ -8343,7 +8470,7 @@
 		"array-ify": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/array-ify/-/array-ify-1.0.0.tgz",
-			"integrity": "sha1-nlKHYrSpBmrRY6aWKjZEGOlibs4=",
+			"integrity": "sha512-c5AMf34bKdvPhQ7tBGhqkgKNUzMr4WUs+WDtC2ZUGOUncbxKMTvqxYctiseW3+L4bA8ec+GcZ6/A/FW4m8ukng==",
 			"dev": true
 		},
 		"array-union": {
@@ -8411,9 +8538,9 @@
 			"dev": true
 		},
 		"c8": {
-			"version": "7.11.2",
-			"resolved": "https://registry.npmjs.org/c8/-/c8-7.11.2.tgz",
-			"integrity": "sha512-6ahJSrhS6TqSghHm+HnWt/8Y2+z0hM/FQyB1ybKhAR30+NYL9CTQ1uwHxuWw6U7BHlHv6wvhgOrH81I+lfCkxg==",
+			"version": "7.11.3",
+			"resolved": "https://registry.npmjs.org/c8/-/c8-7.11.3.tgz",
+			"integrity": "sha512-6YBmsaNmqRm9OS3ZbIiL2EZgi1+Xc4O24jL3vMYGE6idixYuGdy76rIfIdltSKDj9DpLNrcXSonUTR1miBD0wA==",
 			"dev": true,
 			"requires": {
 				"@bcoe/v8-coverage": "^0.2.3",
@@ -8761,9 +8888,9 @@
 			}
 		},
 		"conventional-changelog": {
-			"version": "3.1.24",
-			"resolved": "https://registry.npmjs.org/conventional-changelog/-/conventional-changelog-3.1.24.tgz",
-			"integrity": "sha512-ed6k8PO00UVvhExYohroVPXcOJ/K1N0/drJHx/faTH37OIZthlecuLIRX/T6uOp682CAoVoFpu+sSEaeuH6Asg==",
+			"version": "3.1.25",
+			"resolved": "https://registry.npmjs.org/conventional-changelog/-/conventional-changelog-3.1.25.tgz",
+			"integrity": "sha512-ryhi3fd1mKf3fSjbLXOfK2D06YwKNic1nC9mWqybBHdObPd8KJ2vjaXZfYj1U23t+V8T8n0d7gwnc9XbIdFbyQ==",
 			"dev": true,
 			"requires": {
 				"conventional-changelog-angular": "^5.0.12",
@@ -8814,9 +8941,9 @@
 			"dev": true
 		},
 		"conventional-changelog-conventionalcommits": {
-			"version": "4.6.1",
-			"resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-4.6.1.tgz",
-			"integrity": "sha512-lzWJpPZhbM1R0PIzkwzGBCnAkH5RKJzJfFQZcl/D+2lsJxAwGnDKBqn/F4C1RD31GJNn8NuKWQzAZDAVXPp2Mw==",
+			"version": "4.6.3",
+			"resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-4.6.3.tgz",
+			"integrity": "sha512-LTTQV4fwOM4oLPad317V/QNQ1FY4Hju5qeBIM1uTHbrnCE+Eg4CdRZ3gO2pUeR+tzWdp80M2j3qFFEDWVqOV4g==",
 			"dev": true,
 			"requires": {
 				"compare-func": "^2.0.0",
@@ -9007,9 +9134,9 @@
 			"dev": true
 		},
 		"debug": {
-			"version": "4.3.3",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
-			"integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+			"version": "4.3.4",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+			"integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
 			"dev": true,
 			"requires": {
 				"ms": "2.1.2"
@@ -9800,14 +9927,11 @@
 				"fetch-blob": "^3.1.2"
 			}
 		},
-		"fs-access": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/fs-access/-/fs-access-1.0.1.tgz",
-			"integrity": "sha1-1qh/JiJxzv6+wwxVNAf7mV2od3o=",
-			"dev": true,
-			"requires": {
-				"null-check": "^1.0.0"
-			}
+		"fp-ts": {
+			"version": "2.12.1",
+			"resolved": "https://registry.npmjs.org/fp-ts/-/fp-ts-2.12.1.tgz",
+			"integrity": "sha512-oxvgqUYR6O9VkKXrxkJ0NOyU0FrE705MeqgBUMEPWyTu6Pwn768cJbHChw2XOBlgFLKfIHxjr2OOBFpv2mUGZw==",
+			"peer": true
 		},
 		"fs-extra": {
 			"version": "10.0.0",
@@ -9953,7 +10077,7 @@
 		"git-remote-origin-url": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/git-remote-origin-url/-/git-remote-origin-url-2.0.0.tgz",
-			"integrity": "sha1-UoJlna4hBxRaERJhEq0yFuxfpl8=",
+			"integrity": "sha512-eU+GGrZgccNJcsDH5LkXR3PB9M958hxc7sbA8DFJjrv9j4L2P/eZfKhM+QD6wyzpiv+b1BpK0XrYCxkovtjSLw==",
 			"dev": true,
 			"requires": {
 				"gitconfiglocal": "^1.0.0",
@@ -9981,7 +10105,7 @@
 		"gitconfiglocal": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/gitconfiglocal/-/gitconfiglocal-1.0.0.tgz",
-			"integrity": "sha1-QdBF84UaXqiPA/JMocYXgRRGS5s=",
+			"integrity": "sha512-spLUXeTAVHxDtKsJc8FkFVgFtMdEN9qPGpL23VfSHx4fP4+Ds097IXLvymbnDH8FnmxX5Nr9bPw3A+AQ6mWEaQ==",
 			"dev": true,
 			"requires": {
 				"ini": "^1.3.2"
@@ -10049,14 +10173,6 @@
 				"source-map": "^0.6.1",
 				"uglify-js": "^3.1.4",
 				"wordwrap": "^1.0.0"
-			},
-			"dependencies": {
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
-				}
 			}
 		},
 		"hard-rejection": {
@@ -10210,6 +10326,20 @@
 				"has": "^1.0.3",
 				"side-channel": "^1.0.4"
 			}
+		},
+		"io-ts": {
+			"version": "2.2.16",
+			"resolved": "https://registry.npmjs.org/io-ts/-/io-ts-2.2.16.tgz",
+			"integrity": "sha512-y5TTSa6VP6le0hhmIyN0dqEXkrZeJLeC5KApJq6VLci3UEKF80lZ+KuoUs02RhBxNWlrqSNxzfI7otLX1Euv8Q==",
+			"peer": true,
+			"requires": {}
+		},
+		"io-ts-types": {
+			"version": "0.5.16",
+			"resolved": "https://registry.npmjs.org/io-ts-types/-/io-ts-types-0.5.16.tgz",
+			"integrity": "sha512-h9noYVfY9rlbmKI902SJdnV/06jgiT2chxG6lYDxaYNp88HscPi+SBCtmcU+m0E7WT5QSwt7sIMj93+qu0FEwQ==",
+			"peer": true,
+			"requires": {}
 		},
 		"is-arrayish": {
 			"version": "0.2.1",
@@ -10397,7 +10527,7 @@
 		"isarray": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+			"integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
 			"dev": true
 		},
 		"isexe": {
@@ -10502,7 +10632,7 @@
 		"json-stringify-safe": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-			"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+			"integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
 			"dev": true
 		},
 		"jsonc-parser": {
@@ -11054,9 +11184,9 @@
 			}
 		},
 		"minimist": {
-			"version": "1.2.5",
-			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-			"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+			"version": "1.2.6",
+			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+			"integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
 			"dev": true
 		},
 		"minimist-options": {
@@ -11259,6 +11389,12 @@
 			"integrity": "sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw==",
 			"dev": true
 		},
+		"monocle-ts": {
+			"version": "2.3.13",
+			"resolved": "https://registry.npmjs.org/monocle-ts/-/monocle-ts-2.3.13.tgz",
+			"integrity": "sha512-D5Ygd3oulEoAm3KuGO0eeJIrhFf1jlQIoEVV2DYsZUMz42j4tGxgct97Aq68+F8w4w4geEnwFa8HayTS/7lpKQ==",
+			"requires": {}
+		},
 		"mri": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
@@ -11266,9 +11402,9 @@
 			"dev": true
 		},
 		"nanoid": {
-			"version": "3.3.2",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.2.tgz",
-			"integrity": "sha512-CuHBogktKwpm5g2sRgv83jEy2ijFzBwMoYA60orPDR7ynsLijJDqgsi4RDGj3OJpy3Ieb+LYwiRmIOGyytgITA==",
+			"version": "3.3.4",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
+			"integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==",
 			"dev": true
 		},
 		"nanospinner": {
@@ -11291,6 +11427,12 @@
 			"resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
 			"integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
 			"dev": true
+		},
+		"newtype-ts": {
+			"version": "0.3.5",
+			"resolved": "https://registry.npmjs.org/newtype-ts/-/newtype-ts-0.3.5.tgz",
+			"integrity": "sha512-v83UEQMlVR75yf1OUdoSFssjitxzjZlqBAjiGQ4WJaML8Jdc68LJ+BaSAXUmKY4bNzp7hygkKLYTsDi14PxI2g==",
+			"requires": {}
 		},
 		"nice-try": {
 			"version": "1.0.5",
@@ -11422,12 +11564,6 @@
 			"requires": {
 				"path-key": "^3.0.0"
 			}
-		},
-		"null-check": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/null-check/-/null-check-1.0.0.tgz",
-			"integrity": "sha1-l33/1xdgErnsMNKjnbXPcqBDnt0=",
-			"dev": true
 		},
 		"object-inspect": {
 			"version": "1.12.0",
@@ -11655,16 +11791,16 @@
 		"pify": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-			"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+			"integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
 			"dev": true
 		},
 		"postcss": {
-			"version": "8.4.12",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.12.tgz",
-			"integrity": "sha512-lg6eITwYe9v6Hr5CncVbK70SoioNQIq81nsaG86ev5hAidQvmOeETBqs7jm43K2F5/Ley3ytDtriImV6TpNiSg==",
+			"version": "8.4.14",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.14.tgz",
+			"integrity": "sha512-E398TUmfAYFPBSdzgeieK2Y1+1cpdxJx8yXbK/m57nRhKSmk1GB2tO4lbLBtlkfPQTDKfe4Xqv1ASWPpayPEig==",
 			"dev": true,
 			"requires": {
-				"nanoid": "^3.3.1",
+				"nanoid": "^3.3.4",
 				"picocolors": "^1.0.0",
 				"source-map-js": "^1.0.2"
 			}
@@ -11676,9 +11812,9 @@
 			"dev": true
 		},
 		"prettier": {
-			"version": "2.6.2",
-			"resolved": "https://registry.npmjs.org/prettier/-/prettier-2.6.2.tgz",
-			"integrity": "sha512-PkUpF+qoXTqhOeWL9fu7As8LXsIUZ1WYaJiY/a7McAQzxjk82OF0tibkFXVCDImZtWxbvojFjerkiLb0/q8mew=="
+			"version": "2.7.1",
+			"resolved": "https://registry.npmjs.org/prettier/-/prettier-2.7.1.tgz",
+			"integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g=="
 		},
 		"prettier-linter-helpers": {
 			"version": "1.0.0",
@@ -11964,7 +12100,7 @@
 		"read-pkg-up": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
-			"integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
+			"integrity": "sha512-YFzFrVvpC6frF1sz8psoHDBGF7fLPc+llq/8NB43oagqWkx8ar5zYtsTORtOjw9W2RHLpWP+zTWwBvf1bCmcSw==",
 			"dev": true,
 			"requires": {
 				"find-up": "^2.0.0",
@@ -11974,7 +12110,7 @@
 				"find-up": {
 					"version": "2.1.0",
 					"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-					"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+					"integrity": "sha512-NWzkk0jSJtTt08+FBFMvXoeZnOJD+jTtsRmBYbAIzJdX6l7dLgR7CTubCM5/eDdPUBvLCeVasP1brfVR/9/EZQ==",
 					"dev": true,
 					"requires": {
 						"locate-path": "^2.0.0"
@@ -11983,7 +12119,7 @@
 				"locate-path": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
-					"integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+					"integrity": "sha512-NCI2kiDkyR7VeEKm27Kda/iQHyKJe1Bu0FlTbYp3CqJu+9IFe9bLyAjMxf5ZDDbEg+iMPzB5zYyUTSm8wVTKmA==",
 					"dev": true,
 					"requires": {
 						"p-locate": "^2.0.0",
@@ -12002,7 +12138,7 @@
 				"p-locate": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
-					"integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+					"integrity": "sha512-nQja7m7gSKuewoVRen45CtVfODR3crN3goVQ0DDZ9N3yHxgpkuBhZqsaiotSQRrADUrne346peY7kT3TSACykg==",
 					"dev": true,
 					"requires": {
 						"p-limit": "^1.1.0"
@@ -12011,13 +12147,13 @@
 				"p-try": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
-					"integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+					"integrity": "sha512-U1etNYuMJoIz3ZXSrrySFjsXQTWOx2/jdi86L+2pRvph/qMKL6sbcCYdH23fqsbm8TH2Gn0OybpT4eSFlCVHww==",
 					"dev": true
 				},
 				"path-exists": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-					"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+					"integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
 					"dev": true
 				}
 			}
@@ -12383,6 +12519,12 @@
 				}
 			}
 		},
+		"source-map": {
+			"version": "0.6.1",
+			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+			"dev": true
+		},
 		"source-map-js": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
@@ -12442,22 +12584,21 @@
 			}
 		},
 		"standard-version": {
-			"version": "9.3.2",
-			"resolved": "https://registry.npmjs.org/standard-version/-/standard-version-9.3.2.tgz",
-			"integrity": "sha512-u1rfKP4o4ew7Yjbfycv80aNMN2feTiqseAhUhrrx2XtdQGmu7gucpziXe68Z4YfHVqlxVEzo4aUA0Iu3VQOTgQ==",
+			"version": "9.5.0",
+			"resolved": "https://registry.npmjs.org/standard-version/-/standard-version-9.5.0.tgz",
+			"integrity": "sha512-3zWJ/mmZQsOaO+fOlsa0+QK90pwhNd042qEcw6hKFNoLFs7peGyvPffpEBbK/DSGPbyOvli0mUIFv5A4qTjh2Q==",
 			"dev": true,
 			"requires": {
 				"chalk": "^2.4.2",
-				"conventional-changelog": "3.1.24",
+				"conventional-changelog": "3.1.25",
 				"conventional-changelog-config-spec": "2.1.0",
-				"conventional-changelog-conventionalcommits": "4.6.1",
+				"conventional-changelog-conventionalcommits": "4.6.3",
 				"conventional-recommended-bump": "6.1.0",
 				"detect-indent": "^6.0.0",
 				"detect-newline": "^3.1.0",
 				"dotgitignore": "^2.1.0",
 				"figures": "^3.1.0",
 				"find-up": "^5.0.0",
-				"fs-access": "^1.0.1",
 				"git-semver-tags": "^4.0.0",
 				"semver": "^7.1.1",
 				"stringify-package": "^1.0.1",
@@ -12667,15 +12808,15 @@
 			}
 		},
 		"tinypool": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/tinypool/-/tinypool-0.1.2.tgz",
-			"integrity": "sha512-fvtYGXoui2RpeMILfkvGIgOVkzJEGediv8UJt7TxdAOY8pnvUkFg/fkvqTfXG9Acc9S17Cnn1S4osDc2164guA==",
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/tinypool/-/tinypool-0.1.3.tgz",
+			"integrity": "sha512-2IfcQh7CP46XGWGGbdyO4pjcKqsmVqFAPcXfPxcPXmOWt9cYkTP9HcDmGgsfijYoAEc4z9qcpM/BaBz46Y9/CQ==",
 			"dev": true
 		},
 		"tinyspy": {
-			"version": "0.3.2",
-			"resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-0.3.2.tgz",
-			"integrity": "sha512-2+40EP4D3sFYy42UkgkFFB+kiX2Tg3URG/lVvAZFfLxgGpnWl5qQJuBw1gaLttq8UOS+2p3C0WrhJnQigLTT2Q==",
+			"version": "0.3.3",
+			"resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-0.3.3.tgz",
+			"integrity": "sha512-gRiUR8fuhUf0W9lzojPf1N1euJYA30ISebSfgca8z76FOvXtVXqd5ojEIaKLWbDQhAaC3ibxZIjqbyi4ybjcTw==",
 			"dev": true
 		},
 		"to-regex-range": {
@@ -12744,15 +12885,15 @@
 			"dev": true
 		},
 		"typescript": {
-			"version": "4.6.4",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.4.tgz",
-			"integrity": "sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==",
+			"version": "4.7.4",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
+			"integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
 			"dev": true
 		},
 		"uglify-js": {
-			"version": "3.15.1",
-			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.15.1.tgz",
-			"integrity": "sha512-FAGKF12fWdkpvNJZENacOH0e/83eG6JyVQyanIJaBXCN1J11TUQv1T1/z8S+Z0CG0ZPk1nPcreF/c7lrTd0TEQ==",
+			"version": "3.16.1",
+			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.16.1.tgz",
+			"integrity": "sha512-X5BGTIDH8U6IQ1TIRP62YC36k+ULAa1d59BxlWvPUJ1NkW5L3FwcGfEzuVvGmhJFBu0YJ5Ge25tmRISqCmLiRQ==",
 			"dev": true,
 			"optional": true
 		},
@@ -12877,14 +13018,14 @@
 			}
 		},
 		"vite": {
-			"version": "2.9.6",
-			"resolved": "https://registry.npmjs.org/vite/-/vite-2.9.6.tgz",
-			"integrity": "sha512-3IffdrByHW95Yjv0a13TQOQfJs7L5dVlSPuTt432XLbRMriWbThqJN2k/IS6kXn5WY4xBLhK9XoaWay1B8VzUw==",
+			"version": "2.9.12",
+			"resolved": "https://registry.npmjs.org/vite/-/vite-2.9.12.tgz",
+			"integrity": "sha512-suxC36dQo9Rq1qMB2qiRorNJtJAdxguu5TMvBHOc/F370KvqAe9t48vYp+/TbPKRNrMh/J55tOUmkuIqstZaew==",
 			"dev": true,
 			"requires": {
 				"esbuild": "^0.14.27",
 				"fsevents": "~2.3.2",
-				"postcss": "^8.4.12",
+				"postcss": "^8.4.13",
 				"resolve": "^1.22.0",
 				"rollup": "^2.59.0"
 			},
@@ -12953,7 +13094,7 @@
 		"wordwrap": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-			"integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+			"integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
 			"dev": true
 		},
 		"wrap-ansi": {

--- a/packages/adapter-next/src/hooks/customType-create.ts
+++ b/packages/adapter-next/src/hooks/customType-create.ts
@@ -1,3 +1,4 @@
+import * as prismicT from "@prismicio/types";
 import type {
 	CustomTypeCreateHook,
 	CustomTypeCreateHookData,
@@ -31,7 +32,7 @@ const createTypesFile = async ({ dir, data, helpers, options }: Args) => {
 
 	// TODO: Figure out how to import Shared Slice types
 	let contents = generateTypes({
-		customTypeModels: [data.model],
+		customTypeModels: [data.model as prismicT.CustomTypeModel],
 	});
 
 	if (options.format) {

--- a/packages/adapter-next/src/hooks/slice-create.ts
+++ b/packages/adapter-next/src/hooks/slice-create.ts
@@ -1,3 +1,4 @@
+import * as prismicT from "@prismicio/types";
 import type {
 	SliceCreateHook,
 	SliceCreateHookData,
@@ -101,7 +102,7 @@ const createTypesFile = async ({ dir, data, helpers, options }: Args) => {
 	const filePath = path.join(dir, "types.ts");
 
 	let contents = generateTypes({
-		sharedSliceModels: [data.model],
+		sharedSliceModels: [data.model as prismicT.SharedSliceModel],
 	});
 
 	if (options.format) {

--- a/packages/adapter-next/src/hooks/slice-update.ts
+++ b/packages/adapter-next/src/hooks/slice-update.ts
@@ -1,3 +1,4 @@
+import * as prismicT from "@prismicio/types";
 import type {
 	SliceMachineContext,
 	SliceUpdateHook,
@@ -30,7 +31,7 @@ const updateTypesFile = async ({ dir, data, helpers, options }: Args) => {
 	const filePath = path.join(dir, "types.ts");
 
 	let contents = generateTypes({
-		sharedSliceModels: [data.model],
+		sharedSliceModels: [data.model as prismicT.SharedSliceModel],
 	});
 
 	if (options.format) {

--- a/packages/kit/package.json
+++ b/packages/kit/package.json
@@ -40,19 +40,20 @@
 		"unit:watch": "vitest watch"
 	},
 	"dependencies": {
-		"@prismicio/types": "^0.1.27",
+		"@prismicio/types": "^0.1.29",
+		"@prismicio/types-internal": "^0.3.0",
 		"defu": "^6.0.0",
-		"prettier": "^2.6.2",
+		"prettier": "^2.7.1",
 		"strip-indent": "^4.0.0"
 	},
 	"devDependencies": {
 		"@prismicio/mock": "^0.0.10",
-		"@types/prettier": "^2.6.0",
-		"c8": "^7.11.2",
+		"@types/prettier": "^2.6.3",
+		"c8": "^7.11.3",
 		"siroc": "^0.16.0",
-		"standard-version": "^9.3.2",
-		"typescript": "^4.6.4",
-		"vitest": "^0.10.0"
+		"standard-version": "^9.5.0",
+		"typescript": "^4.7.4",
+		"vitest": "^0.15.2"
 	},
 	"engines": {
 		"node": ">=12.7.0"

--- a/packages/kit/src/createSliceMachineActions.ts
+++ b/packages/kit/src/createSliceMachineActions.ts
@@ -1,7 +1,10 @@
-import * as prismicT from "@prismicio/types";
-
 import { HookSystem } from "./lib";
-import { SliceMachineProject, SliceMachineHooks, SliceLibrary } from "./types";
+import {
+	SliceMachineProject,
+	SliceMachineHooks,
+	SliceLibrary,
+	SharedSliceModel,
+} from "./types";
 
 type GetSliceModelArgs = {
 	libraryID: string;
@@ -21,7 +24,7 @@ type NotifyArgs = {
  * Slice Machine actions shared to plugins and hooks.
  */
 export type SliceMachineActions = {
-	getSliceModel(args: GetSliceModelArgs): Promise<prismicT.SharedSliceModel>;
+	getSliceModel(args: GetSliceModelArgs): Promise<SharedSliceModel>;
 	readLibrary(
 		args: ReadLibraryArgs,
 	): Promise<SliceLibrary & { sliceIDs: string[] }>;

--- a/packages/kit/src/types.ts
+++ b/packages/kit/src/types.ts
@@ -1,7 +1,5 @@
-// TODO: This may need to be replaced with @prismicio/types-internal.
-//       Be aware of the implications of exposing @prismicio/types-internal as
-//       part of the public API; it would no longer be "internal."
 import * as prismicT from "@prismicio/types";
+import * as prismicTI from "@prismicio/types-internal";
 
 import { SliceMachineContext } from "./createSliceMachineContext";
 
@@ -41,6 +39,26 @@ export type SliceMachineProject = {
 export type SliceLibrary = {
 	id: string;
 };
+
+// ============================================================================
+// ## Internal and External Type Unions
+// ============================================================================
+
+export type SharedSliceModel =
+	| prismicT.SharedSliceModel
+	| prismicTI.CustomTypes.Widgets.Slices.SharedSlice;
+
+export type CustomTypeModel =
+	| prismicT.CustomTypeModel
+	| prismicTI.CustomTypes.CustomType;
+
+export type CustomTypeModelFieldForGroup =
+	| prismicT.CustomTypeModelFieldForGroup
+	| prismicTI.CustomTypes.Widgets.Nestable.NestableWidget;
+
+export type CustomTypeModelField =
+	| prismicT.CustomTypeModelField
+	| prismicTI.CustomTypes.Widgets.Widget.DynamicWidget;
 
 // ============================================================================
 //
@@ -114,7 +132,7 @@ export type SliceMachineHooks = {
 
 export type SliceCreateHookData = {
 	libraryID: string;
-	model: prismicT.SharedSliceModel;
+	model: SharedSliceModel;
 };
 export type SliceCreateHookBase = SliceMachineHook<SliceCreateHookData, void>;
 export type SliceCreateHook<
@@ -127,7 +145,7 @@ export type SliceCreateHook<
 
 export type SliceUpdateHookData = {
 	libraryID: string;
-	model: prismicT.SharedSliceModel;
+	model: SharedSliceModel;
 };
 export type SliceUpdateHookBase = SliceMachineHook<SliceUpdateHookData, void>;
 export type SliceUpdateHook<
@@ -140,7 +158,7 @@ export type SliceUpdateHook<
 
 export type SliceDeleteHookData = {
 	libraryID: string;
-	model: prismicT.SharedSliceModel;
+	model: SharedSliceModel;
 };
 export type SliceDeleteHookBase = SliceMachineHook<SliceDeleteHookData, void>;
 export type SliceDeleteHook<
@@ -157,7 +175,7 @@ export type SliceReadHookData = {
 };
 export type SliceReadHookBase = SliceMachineHook<
 	SliceReadHookData,
-	prismicT.SharedSliceModel
+	SharedSliceModel
 >;
 export type SliceReadHook<
 	TPluginOptions extends PluginOptions = PluginOptions,
@@ -168,7 +186,7 @@ export type SliceReadHook<
 // ============================================================================
 
 export type CustomTypeCreateHookData = {
-	model: prismicT.CustomTypeModel;
+	model: CustomTypeModel;
 };
 export type CustomTypeCreateHookBase = SliceMachineHook<
 	CustomTypeCreateHookData,
@@ -183,7 +201,7 @@ export type CustomTypeCreateHook<
 // ============================================================================
 
 export type CustomTypeUpdateHookData = {
-	model: prismicT.CustomTypeModel;
+	model: CustomTypeModel;
 };
 export type CustomTypeUpdateHookBase = SliceMachineHook<
 	CustomTypeUpdateHookData,
@@ -198,7 +216,7 @@ export type CustomTypeUpdateHook<
 // ============================================================================
 
 export type CustomTypeDeleteHookData = {
-	model: prismicT.CustomTypeModel;
+	model: CustomTypeModel;
 };
 export type CustomTypeDeleteHookBase = SliceMachineHook<
 	CustomTypeDeleteHookData,
@@ -217,7 +235,7 @@ export type CustomTypeReadHookData = {
 };
 export type CustomTypeReadHookBase = SliceMachineHook<
 	CustomTypeReadHookData,
-	prismicT.CustomTypeModel
+	CustomTypeModel
 >;
 export type CustomTypeReadHook<
 	TPluginOptions extends PluginOptions = PluginOptions,
@@ -237,13 +255,13 @@ export type SnippetReadHookData = {
 } & (
 	| {
 			rootModelType: typeof SnippetReadHookDataRootModelType.Slice;
-			rootModel: prismicT.SharedSliceModel;
-			model: prismicT.CustomTypeModelFieldForGroup;
+			rootModel: SharedSliceModel;
+			model: CustomTypeModelFieldForGroup;
 	  }
 	| {
 			rootModelType: typeof SnippetReadHookDataRootModelType.CustomType;
-			rootModel: prismicT.CustomTypeModel;
-			model: prismicT.CustomTypeModelField;
+			rootModel: CustomTypeModel;
+			model: CustomTypeModelField;
 	  }
 );
 export type SnippetDescriptor = {


### PR DESCRIPTION
Well, this was a bumpy road!

I explored multiple approaches:

## 1. Having two sets of hook types (one internal, one external)

The idea here was just to duplicate hook types and retyping them using `@prismicio/types-internal` to then cast the `HookSystem` instance returned to Slice Machine by `createSliceMachineHookSystem()`

**Pros:**
- Simple mental model

**Cons:**
- Hard to maintain
- Types are not tied and things could be mistyped

## 2. Transforming external hook types into internal hook types using type helpers

This idea was quite similar to the previous ones, but would traverse hook types to replace external types with internal ones, e.g.:

```typescript
type TraverseData<Data extends Record<string, unknown>> = {
	[key in keyof Data]: Data[key] extends ExternalType
		? InternalTypeEquivalent
		: /* ... */
}
```

**Pros:**
- Easy to maintain

**Cons:**
- Types are not tired and things could be mistyped
- Hard to read/lot of edge cases to handle with `Traverse`

## 3. Having types being unions

While working on that I noticed we're not using a ton of types, 4: `SharedSliceModel`, `CustomTypeModel`, `CustomTypeModelFieldForGroup`, and `CustomTypeModelField`. Those types are _relatively_ close whether they come from `@prismicio/types` and `@prismicio/types-internal`, so the idea here was just to use a union of internal and external definitions (`Internal | External`)

**Pros:**
- Simple mental model
- Easy to maintain
- Types are strongly tied, only properties in common are accessible

**Cons:**
- There are some edge cases where model types need to be fully defined following one of the definitions (internal or external) that requires some type assertions (e.g. https://github.com/lihbr/prismic-slice-machine-plugin-exploration/blob/lh/types-internal/packages/adapter-next/src/hooks/slice-create.ts#L105). This could be mitigated using different approaches:
   - For Slice Machine team using `io-ts` validators
   - For plugin authors using TypeScript helpers (e.g. `const External = (obj: Internal | External): External => obj as External`)

All of this is still quite in an exploratory phase, but happy to get your input 🤷‍♀️

---

**Related:** I also explored updating `@prismicio/types` model definition from `@prismicio/types-internal` there: https://github.com/prismicio/prismic-types/pull/43, but I'm not convinced 🤔 